### PR TITLE
投稿用のAPIを抽象化するtraitを実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,9 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 name = "utils"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "bytes",
+ "interface",
  "webbrowser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,10 +1224,12 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 name = "twitter_api"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64",
  "bytes",
  "chrono",
  "hmac-sha1",
+ "interface",
  "rand",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,9 +59,9 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
@@ -151,7 +162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -168,7 +179,7 @@ checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -461,6 +472,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "interface"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,7 +696,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -754,18 +773,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -942,7 +961,7 @@ checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1035,6 +1054,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1104,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1131,7 +1161,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1334,7 +1364,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -1368,7 +1398,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ name = "base"
 version = "0.1.0"
 dependencies = [
  "dotenv",
+ "interface",
  "reqwest",
  "spotify_api",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "base",
     "spotify_api",
     "twitter_api",
-    "utils"
+    "utils",
+    "interface"
 ]

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 dotenv = "0.15.0"
 tokio = { version = "1", features = ["full"] }
+interface = {path = "../interface"}
 twitter_api = {path = "../twitter_api"}
 spotify_api = {path = "../spotify_api"}
 reqwest = { version = "0.11.13", features = ["json", "blocking", "multipart"] }

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "interface"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.72"
+bytes = "1.4.0"

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -10,9 +10,9 @@ pub trait PostAPI {
     
     async fn compose_without_picture(
         &self, text: &str
-    ) -> String;
+    ) -> Result<(), String>;
     
     async fn compose_with_picture(
         &self, text: &str, media: &Vec<String>
-    ) -> String;
+    ) -> Result<(), String>;
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+
+/// An API functions for compose posting is represented here
+#[async_trait]
+pub trait PostAPI {
+    async fn upload_media(
+        &self, picture: Bytes
+    ) -> Option<String>;
+    
+    async fn compose_without_picture(
+        &self, text: &str
+    ) -> String;
+    
+    async fn compose_with_picture(
+        &self, text: &str, media: &Vec<String>
+    ) -> String;
+}

--- a/twitter_api/Cargo.toml
+++ b/twitter_api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 utils = { path = "../utils" }
+interface = { path = "../interface" }
 url = "2.3.1"
 rand = "0.8.5"
 chrono = "0.4.23"
@@ -18,3 +19,4 @@ serde_json = "1.0"
 hmac-sha1 = "0.1.3"
 urlencoding = "2.1.2"
 bytes = "1"
+async-trait = "0.1.72"

--- a/twitter_api/src/api_model/api.rs
+++ b/twitter_api/src/api_model/api.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use reqwest::multipart;
 use bytes::Bytes;
 use serde::Deserialize;
+use interface::PostAPI;
+use async_trait::async_trait;
 
 #[allow(dead_code)]
 pub struct Api {
@@ -42,8 +44,11 @@ impl Api {
             ).await
         }
     }
+}
 
-    pub async fn compose_new_tweet(&self, text: &str) -> Result<reqwest::Response, reqwest::Error> {
+#[async_trait]
+impl PostAPI for Api {
+    async fn compose_without_picture(&self, text: &str) -> Result<(), String> {
         let request_url = "https://api.twitter.com/1.1/statuses/update.json";
         let url = url::Url::parse(&request_url).unwrap();
         
@@ -60,19 +65,17 @@ impl Api {
         let client = reqwest::Client::new();
         let req = client.post(request_url).body(body);
 
-        self.session.post(
-            req,
-            &url,
-            &request_param,
-            &extra_oauth_param
-        ).await
+        match self.session.post(req, &url, &request_param, &extra_oauth_param).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string())
+        }
     }
 
-    pub async fn compose_new_tweet_with_media(
+    async fn compose_with_picture(
         &self,
         text: &str,
         media: &Vec<String>
-    ) -> Result<reqwest::Response, reqwest::Error> {
+    ) -> Result<(), String> {
         let request_url = "https://api.twitter.com/1.1/statuses/update.json";
         let url = url::Url::parse(&request_url).unwrap();
         
@@ -92,15 +95,13 @@ impl Api {
         let client = reqwest::Client::new();
         let req = client.post(request_url).body(body);
 
-        self.session.post(
-            req,
-            &url,
-            &request_param,
-            &extra_oauth_param
-        ).await
+        match self.session.post(req, &url, &request_param, &extra_oauth_param).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string())
+        }
     }
 
-    pub async fn upload_picture(&self, picture: Bytes) -> Option<String> {
+    async fn upload_media(&self, picture: Bytes) -> Option<String> {
         let request_url = "https://upload.twitter.com/1.1/media/upload.json";
         let url = url::Url::parse(&request_url).unwrap();
         

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 webbrowser = "0.8.10"
+interface = { path="../interface" }
+async-trait = "0.1.72"
+bytes = "1.4.0"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -23,7 +23,7 @@ pub mod MockPostAPI {
     }
 
     impl SuccessPostAPI {
-        fn new(api_key: String, api_secret: String) -> Self {
+        pub fn new(api_key: String, api_secret: String) -> Self {
             SuccessPostAPI {
                 api_key: api_key.clone(),
                 api_secret: api_secret.clone()

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -9,3 +9,40 @@ pub async fn throw_url(carg: &str) -> Result<(), String> {
         }
     }
 }
+
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+pub mod MockPostAPI {
+    use async_trait::async_trait;
+    use interface::PostAPI;
+    use bytes::Bytes;
+
+    pub struct SuccessPostAPI {
+        api_key: String,
+        api_secret: String
+    }
+
+    impl SuccessPostAPI {
+        fn new(api_key: String, api_secret: String) -> Self {
+            SuccessPostAPI {
+                api_key: api_key.clone(),
+                api_secret: api_secret.clone()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PostAPI for SuccessPostAPI {
+        async fn upload_media(&self, _picture: Bytes) -> Option<String> {
+            Some("hoge".to_string())
+        }
+
+        async fn compose_without_picture(&self, _text: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn compose_with_picture(&self, _text: &str, _media: &Vec<String>) -> Result<(), String> {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
What
- Twitter/Misskey APIなどを抽象化するtraitを実装した
- 画像のアップロード、画像なしでの投稿、画像ありでの投稿の3つを実装させるinterface
- main.rsで今まではTwitterAPIの有効なインスタンスに依存していたが、utils配下にPostAPIを継承したmock APIを生やしたため、main.rsの依存性が減り、デバッグが容易になった

Why
close #38 

How

> interface/src/lib.rs
```rust
#[async_trait]
pub trait PostAPI {
    async fn upload_media(
        &self, picture: Bytes
    ) -> Option<String>;

    async fn compose_without_picture(
        &self, text: &str
    ) -> Result<(), String>;

    async fn compose_with_picture(
        &self, text: &str, media: &Vec<String>
    ) -> Result<(), String>;
}
```