### PR TITLE
Misskey用のファイルを準備

### DIFF
--- a/misskey_api/src/api.rs
+++ b/misskey_api/src/api.rs
@@ -10,7 +10,7 @@ pub struct MisskeyApi {
 impl MisskeyApi {
     pub fn new(code: String) -> Self {
         MisskeyApi {
-            access_code: code;
+            access_code: code
         }
     }
 

--- a/misskey_api/src/api.rs
+++ b/misskey_api/src/api.rs
@@ -8,7 +8,7 @@ pub struct MisskeyApi {
 impl MisskeyApi {
     pub fn new(code: String) -> Self {
         MisskeyApi {
-            access_code: code.clone()
+            access_code: code;
         }
     }
 

--- a/misskey_api/src/api.rs
+++ b/misskey_api/src/api.rs
@@ -15,6 +15,10 @@ impl MisskeyApi {
     pub async fn check_picture_exist(picture: &Bytes) -> Result<bool, String> {
         TODO!()
     }
+
+    fn hash_picture(picture: &Bytes) -> String {
+        TODO!()
+    }
 }
 
 #[async_trait]

--- a/misskey_api/src/api.rs
+++ b/misskey_api/src/api.rs
@@ -1,0 +1,33 @@
+use interface::PostAPI;
+
+#[allow(dead_code)]
+pub struct MisskeyApi {
+    access_code: String
+}
+
+impl MisskeyApi {
+    pub fn new(code: String) -> Self {
+        MisskeyApi {
+            access_code: code.clone()
+        }
+    }
+
+    pub async fn check_picture_exist(picture: &Bytes) -> Result<bool, String> {
+        TODO!()
+    }
+}
+
+#[async_trait]
+impl PostAPI for MisskeyApi {
+    async fn compose_without_picture(&self, text: &str) -> Result<(), String> {
+        TODO!()
+    }
+
+    async fn compose_with_picture(&self, text: &str, media: &Vec<String>) -> Result<(), String> {
+        TODO!()
+    }
+
+    async fn upload_media(&self, picture: Bytes) -> Option<String> {
+        TODO!()
+    }
+}

--- a/misskey_api/src/api.rs
+++ b/misskey_api/src/api.rs
@@ -1,4 +1,6 @@
 use interface::PostAPI;
+use async_trait::async_trait;
+use bytes::Bytes;
 
 #[allow(dead_code)]
 pub struct MisskeyApi {
@@ -13,25 +15,25 @@ impl MisskeyApi {
     }
 
     pub async fn check_picture_exist(picture: &Bytes) -> Result<bool, String> {
-        TODO!()
+        todo!()
     }
 
     fn hash_picture(picture: &Bytes) -> String {
-        TODO!()
+        todo!()
     }
 }
 
 #[async_trait]
 impl PostAPI for MisskeyApi {
     async fn compose_without_picture(&self, text: &str) -> Result<(), String> {
-        TODO!()
+        todo!()
     }
 
     async fn compose_with_picture(&self, text: &str, media: &Vec<String>) -> Result<(), String> {
-        TODO!()
+        todo!()
     }
 
     async fn upload_media(&self, picture: Bytes) -> Option<String> {
-        TODO!()
+        todo!()
     }
 }

--- a/misskey_api/src/lib.rs
+++ b/misskey_api/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod types;

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -1,16 +1,16 @@
 pub struct CreatingNote {
-    //! A type of request body of notes/create
-    //! Please notice that this is very limited difinition.
-    //! You can extend this type to change other note options.
-    //!
-    //! To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
+    /// A type of request body of notes/create
+    /// Please notice that this is very limited difinition.
+    /// You can extend this type to change other note options.
+    ///
+    /// To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
 
     pub text: String,         // Body
     pub mediaIds: Vec<String> // Pictures? (I don't know the difference between 'fileIds: Vec<String>')
 }
 
+/// A type represents a misskey user
 pub struct User {
-    //! A type represents a misskey user
 
     pub id: String,
     pub name: Option<String>,
@@ -25,16 +25,16 @@ pub struct User {
     pub onlineStatus: Option<String>
 }
 
+/// Responses of Misskey backend (API)
 pub mod Responses {
-    //! Responses of Misskey backend (API)
+    use super::User;
 
+    /// Response of notes/create 200 (OK)
+    /// Please notice that this is an **INCOMPLETE** definition.
+    /// Some optional parameters could be dropped at parse.
+    ///
+    /// To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
     pub struct CreatedNote {
-        //! Response of notes/create 200 (OK)
-        //! Please notice that this is an **INCOMPLETE** definition.
-        //! Some optional parameters could be dropped at parse.
-        //!
-        //! To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
-        
         pub id: String,
         pub createdAt: String,
         pub text: Option<String>,

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -1,0 +1,56 @@
+pub struct CreatingNote {
+    //! A type of request body of notes/create
+    //! Please notice that this is very limited difinition.
+    //! You can extend this type to change other note options.
+    //!
+    //! To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
+
+    pub text: String,         // Body
+    pub mediaIds: Vec<String> // Pictures? (I don't know the difference between 'fileIds: Vec<String>')
+}
+
+pub struct User {
+    //! A type represents a misskey user
+
+    pub id: String,
+    pub name: Option<String>,
+    pub username: String,
+    pub host: Option<String>, //The local host is represented with None.
+    pub avatarUrl: Option<String>,
+    pub avatarBlurhash: Option<String>,
+    pub isAdmin: Option<bool>,
+    pub isModerator: Option<bool>,
+    pub isBot: Option<bool>,
+    pub isCat: Option<bool>,
+    pub onlineStatus: Option<String>
+}
+
+pub mod Responses {
+    //! Responses of Misskey backend (API)
+
+    pub struct CreatedNote {
+        //! Response of notes/create 200 (OK)
+        //! Please notice that this is an **INCOMPLETE** definition.
+        //! Some optional parameters could be dropped at parse.
+        //!
+        //! To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
+        
+        pub id: String,
+        pub createdAt: String,
+        pub text: Option<String>,
+        pub cw: Option<String>,
+        pub userId: String,
+        pub user: User,
+        pub visibility: String,
+        pub uri: Option<String>,
+        pub url: Option<String>
+    }
+
+    pub struct CommonError {
+        //! A common type for an error response
+
+        pub code: String,
+        pub message: String,
+        pub id: String
+    }
+}

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -12,6 +12,13 @@ pub struct CreatingNote {
     pub mediaIds: Vec<String> // Pictures? (I don't know the difference between 'fileIds: Vec<String>')
 }
 
+/// A type used to make a request for drive/files/find-by-hash
+#[derive(Serialize, Debug)]
+#[allow(non_snake_case)]
+pub struct Md5Container {
+    pub md5: String
+}
+
 /// A type represents a misskey user
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
@@ -97,6 +104,13 @@ pub mod Responses {
         pub filesCount: Option<i32>,
         pub parentId: Option<String>,
         pub parent: Option<Box<DriveFile>>
+    }
+
+    /// Response of drive/files/find*
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
+    pub struct FileSearchResult {
+        pub result: Vec<DriveFile>
     }
 
     /// A common type for an error response

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -1,3 +1,6 @@
+use serde::Deserialize;
+
+#[allow(non_snake_case)]
 pub struct CreatingNote {
     /// A type of request body of notes/create
     /// Please notice that this is very limited difinition.
@@ -10,6 +13,8 @@ pub struct CreatingNote {
 }
 
 /// A type represents a misskey user
+#[derive(Deserialize, Debug)]
+#[allow(non_snake_case)]
 pub struct User {
 
     pub id: String,
@@ -26,14 +31,18 @@ pub struct User {
 }
 
 /// Responses of Misskey backend (API)
+#[allow(non_snake_case)]
 pub mod Responses {
     use super::User;
-
+    use serde::Deserialize;
+    
     /// Response of notes/create 200 (OK)
     /// Please notice that this is an **INCOMPLETE** definition.
     /// Some optional parameters could be dropped at parse.
     ///
     /// To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
     pub struct CreatedNote {
         pub id: String,
         pub createdAt: String,
@@ -46,6 +55,8 @@ pub mod Responses {
         pub url: Option<String>
     }
 
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
     pub struct DriveFile {
         pub id: String,
         pub name: String,
@@ -65,6 +76,8 @@ pub mod Responses {
         pub user: Option<User>
     }
 
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
     pub struct ImgProperties {
         pub width: i32,
         pub height: i32,
@@ -72,6 +85,8 @@ pub mod Responses {
         pub avgColor: String
     }
 
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
     pub struct DriveFolder {
         pub id: String,
         pub createdAt: String,
@@ -83,6 +98,8 @@ pub mod Responses {
     }
 
     /// A common type for an error response
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
     pub struct CommonError {
         pub code: String,
         pub message: String,

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -46,9 +46,44 @@ pub mod Responses {
         pub url: Option<String>
     }
 
-    pub struct CommonError {
-        //! A common type for an error response
+    pub struct DriveFile {
+        pub id: String,
+        pub name: String,
+        #[serde(rename = "type")]
+        pub format: String,
+        pub md5: String,
+        pub size: i32,
+        pub isSensitive: bool,
+        pub blurhash: Option<String>,
+        pub properties: ImgProperties,
+        pub url: Option<String>,
+        pub thumbnailUrl: Option<String>,
+        pub comment: Option<String>,
+        pub folderId: Option<String>,
+        pub folder: Option<DriveFolder>,
+        pub userId: Option<String>,
+        pub user: Option<User>
+    }
 
+    pub struct ImgProperties {
+        pub width: i32,
+        pub height: i32,
+        pub orientation: i32,
+        pub avgColor: String
+    }
+
+    pub struct DriveFolder {
+        pub id: String,
+        pub createdAt: String,
+        pub name: String,
+        pub foldersCount: Option<i32>,
+        pub filesCount: Option<i32>,
+        pub parentId: Option<String>,
+        pub parent: Option<Box<DriveFile>>
+    }
+
+    /// A common type for an error response
+    pub struct CommonError {
         pub code: String,
         pub message: String,
         pub id: String

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -55,6 +55,7 @@ pub mod Responses {
         pub url: Option<String>
     }
 
+    /// A type that represents a file in drive
     #[derive(Deserialize, Debug)]
     #[allow(non_snake_case)]
     pub struct DriveFile {
@@ -85,6 +86,7 @@ pub mod Responses {
         pub avgColor: String
     }
 
+    /// A type that represents a folder in drive
     #[derive(Deserialize, Debug)]
     #[allow(non_snake_case)]
     pub struct DriveFolder {

--- a/misskey_api/src/types.rs
+++ b/misskey_api/src/types.rs
@@ -1,13 +1,13 @@
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
+/// A type of request body of notes/create
+/// Please notice that this is very limited difinition.
+/// You can extend this type to change other note options.
+///
+/// To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
+#[derive(Serialize, Debug)]
 #[allow(non_snake_case)]
 pub struct CreatingNote {
-    /// A type of request body of notes/create
-    /// Please notice that this is very limited difinition.
-    /// You can extend this type to change other note options.
-    ///
-    /// To find complete definition, please read https://post.yourein.net/api-doc#tag/notes/operation/notes/create
-
     pub text: String,         // Body
     pub mediaIds: Vec<String> // Pictures? (I don't know the difference between 'fileIds: Vec<String>')
 }


### PR DESCRIPTION
close #32 

ファイル構造は上のissueで書いているようなものではなくて、最も簡単な形にした。
Twitter_apiやSpotify_apiを使う上で、わざわざapi_modelを呼びに行くのが面倒だったし、そもそもapi_modelは適切な名前ではなかった。