### PR TITLE
base64::encode()をやめる

### DIFF
--- a/spotify_api/src/api_model/credentials.rs
+++ b/spotify_api/src/api_model/credentials.rs
@@ -14,7 +14,7 @@ pub mod Code {
     use std::net::TcpListener;
     use utils::throw_url;
     use reqwest;
-    use base64;
+    use base64::{Engine as _, engine::general_purpose};
     use serde::Deserialize;
     use std::collections::HashMap;
     
@@ -113,7 +113,7 @@ pub mod Code {
 
         fn make_auth_header(&self) -> String {
             let original = format!{"{}:{}", self.client_id, self.secret_id};
-            base64::encode(original)
+            general_purpose::STANDARD_NO_PAD.encode(original)
         }
 
         pub async fn perform_auth(&mut self) 

--- a/twitter_api/src/api_model/oauth1_header.rs
+++ b/twitter_api/src/api_model/oauth1_header.rs
@@ -5,6 +5,7 @@ use std::str;
 use rand::{thread_rng, Rng};
 use rand::distributions::Alphanumeric;
 use url::Url;
+use base64::{Engine as _, engine::general_purpose};
 
 pub struct OAuthHeader {
     pub signature: String,
@@ -83,7 +84,7 @@ impl OAuthHeader {
         let base = format!{"{}&{}&{}", request_method, p_encode(&(Self::get_base_url(url))), p_encode(&param_string)};
         let hash = hmacsha1::hmac_sha1(crypt_key.as_bytes(), base.as_bytes());
         
-        base64::encode(&hash).to_string()
+        general_purpose::STANDARD_NO_PAD.encode(&hash)
     }
 
     fn get_base_url(url: &Url) -> String {
@@ -102,7 +103,7 @@ impl OAuthHeader {
             .map(char::from)
             .collect();
 
-        let b64_encoded_str: String = base64::encode(rand_str);
+        let b64_encoded_str = general_purpose::STANDARD_NO_PAD.encode(rand_str);
         let res = b64_encoded_str.replace(&['+', '/', '='], "");
 
         res


### PR DESCRIPTION
close #47 

deprecatedのため